### PR TITLE
Random roll for each die

### DIFF
--- a/python_files/project_364_dice_roller/dice_roller.py
+++ b/python_files/project_364_dice_roller/dice_roller.py
@@ -22,7 +22,7 @@ def roll_dice(dice_input: DiceInput) -> List[int]:
 def roll_die(dice_roll: DiceRoll) -> int:
     num_dice = dice_roll[0]
     num_sides = dice_roll[1]
-    list_of_die_values = num_dice * [randint(1, num_sides)]
+    list_of_die_values = [randint(1, num_sides) for _ in num_dice]
     return sum(list_of_die_values)
 
 

--- a/python_files/project_364_dice_roller/dice_roller.py
+++ b/python_files/project_364_dice_roller/dice_roller.py
@@ -10,8 +10,8 @@ DiceRoll = Tuple[int, int]
 DiceInput = List[DiceRoll]
 
 
-def dice_roll(input: List[str]) -> List[int]:
-    dice_input = convert_input_str_to_dice_input(input)
+def dice_roll(input_str: List[str]) -> List[int]:
+    dice_input = convert_input_str_to_dice_input(input_str)
     return roll_dice(dice_input)
 
 
@@ -19,10 +19,10 @@ def roll_dice(dice_input: DiceInput) -> List[int]:
     return list(map(roll_die, dice_input))
 
 
-def roll_die(dice_roll: DiceRoll) -> int:
-    num_dice = dice_roll[0]
-    num_sides = dice_roll[1]
-    list_of_die_values = [randint(1, num_sides) for _ in num_dice]
+def roll_die(the_dice_roll: DiceRoll) -> int:
+    num_dice = the_dice_roll[0]
+    num_sides = the_dice_roll[1]
+    list_of_die_values = [randint(1, num_sides) for _ in [1] * num_dice]
     return sum(list_of_die_values)
 
 


### PR DESCRIPTION
Fixed a bug in the dice roller implementation after reviewing the code.

Before I was selecting a random number placing it into a string and extending it num_dice in length.

That's not what I meant to do. Instead, I created a list of 1 num_dice and length and used a generator to generate an equally long list of random numbers. 

This is why code reviews are important!